### PR TITLE
resetActions when freeing MKtl

### DIFF
--- a/Modality/Classes/MKtl/MKtl.sc
+++ b/Modality/Classes/MKtl/MKtl.sc
@@ -673,6 +673,7 @@ MKtl { // abstract class
 
 	closeDevice {
 		if ( device.isNil ){ ^this };
+		this.resetActions;
 		device.closeDevice;
 		device = nil;
 	}


### PR DESCRIPTION
Added a call to resetActions to the closeDevice method so that actions are reset when freeing an MKtl.