### PR TITLE
Add call to cleanupElementsAndCollectives

### DIFF
--- a/Modality/Classes/MIDI/MIDIMKtlDevice.sc
+++ b/Modality/Classes/MIDI/MIDIMKtlDevice.sc
@@ -44,6 +44,7 @@ MIDIMKtlDevice : MKtlDevice {
 	}
 
 	closeDevice {
+		this.cleanupElementsAndCollectives;
 		destination.notNil.if {
 			if ( thisProcess.platform.name == \linux ) {
 				midiOut.disconnect( MIDIClient.destinations.indexOf(destination) )

--- a/Modality/Classes/MKtl/MKtl.sc
+++ b/Modality/Classes/MKtl/MKtl.sc
@@ -673,6 +673,7 @@ MKtl { // abstract class
 
 	closeDevice {
 		if ( device.isNil ){ ^this };
+		this.resetActions;
 		device.closeDevice;
 		device = nil;
 	}


### PR DESCRIPTION
Make sure to cleanupElementsAndCollectives when closing device. This is only missing from MIDIMKtlDevice.