### PR TITLE
Remove erroneous block end

### DIFF
--- a/Modality/HelpSource/Tutorials/How_to_create_a_description_file_for_MIDI.schelp
+++ b/Modality/HelpSource/Tutorials/How_to_create_a_description_file_for_MIDI.schelp
@@ -132,8 +132,6 @@ MIDIIn.noteOnZeroAsNoteOff = false; // send noteOn with velocity 0 as noteOn 0
 MIDIIn.noteOnZeroAsNoteOff = true; // send noteOn with velocity 0 as noteOff 0
 ::
 For details, see link::https://github.com/supercollider/supercollider/issues/1483:: and link::https://github.com/supercollider/supercollider/pull/1488::
-::
-
 
 As a first example, we now create an link::Classes/MKtl:: containing exactly one link::Classes/MKtlElement:: that responds to a code::noteOn:: event. For mapping its velocity we use the code::spec: \midiVel:: identifier, which tells the system to normalise the raw value range of velocity values (code::0:: to code::127::) to values between code::0:: and code::1::.
 


### PR DESCRIPTION
This is causing the following error on load:

```
SCDoc: Indexing help-files...
SCDoc: Indexed 2448 documents in 1.07 seconds
ERROR: In /home/joe/.local/share/SuperCollider/Extensions/Modality/Modality/HelpSource/Tutorials/How_to_create_a_description_file_for_MIDI.schelp:
  At line 135: syntax error, unexpected ::, expecting end of file
```