### PR TITLE
Desc simplify shared dict

### DIFF
--- a/Modality/Classes/GUI/MKtlGUI.sc
+++ b/Modality/Classes/GUI/MKtlGUI.sc
@@ -265,10 +265,14 @@ MKtlGUI {
 			});
 		};
 
-		// // was:
-		// elemsToShow = mktl.elementGroup.flat;
 		// keep groups with a groupType together
-		elemsToShow = mktl.elementGroup.elements.flatIf { |el| el.groupType.isNil };
+		////// this is not ideal, because groupType has to be defined
+		////// at the exact level it applies, and cannot be set at higher levels.
+		///// so, how to do this best?
+		elemsToShow = mktl.elementGroup.elements.flatIf { |el|
+			el.groupType.isNil
+		};
+
 		"%: will show %'s % elements in % views.\n".postf(thisMethod, mktl,
 			mktl.elementsDict.size, elemsToShow.size);
 

--- a/Modality/Classes/GUI/MKtlGUI.sc
+++ b/Modality/Classes/GUI/MKtlGUI.sc
@@ -280,8 +280,6 @@ MKtlGUI {
 			?? { try { item.elemDesc[ \shared ][ \style ] } }
 			?? { ( row: 0, column: 0, width: 0, height: 0 ) };
 
-			[item, style].postln;
-
 			if( pages.notNil && { item.elemDesc[ \page ].notNil }) {
 				parView = pageComposites[ item.elemDesc[ \page ] ];
 			};

--- a/Modality/Classes/GUI/MKtlGUI.sc
+++ b/Modality/Classes/GUI/MKtlGUI.sc
@@ -276,7 +276,12 @@ MKtlGUI {
 			var style, bounds, parView = parent, redirView, newViews;
 			var itemIsGroup = item.isKindOf(MKtlElementGroup);
 
-			style = try { item.elemDesc[ \style ] } ?? { ( row: 0, column: 0, width: 0, height: 0 ) };
+			style = try { item.elemDesc[ \style ] }
+			?? { try { item.elemDesc[ \shared ][ \style ] } }
+			?? { ( row: 0, column: 0, width: 0, height: 0 ) };
+
+			[item, style].postln;
+
 			if( pages.notNil && { item.elemDesc[ \page ].notNil }) {
 				parView = pageComposites[ item.elemDesc[ \page ] ];
 			};

--- a/Modality/Classes/MKtl/MKtlDesc.sc
+++ b/Modality/Classes/MKtl/MKtlDesc.sc
@@ -965,23 +965,31 @@ MKtlDesc {
 	getMidiMsgTypes {
 		var msgTypesUsed = Set.new;
 		var type, missing = List[];
+		var excludeKeys = [\shared, \style ];
 
 		this.elementsDesc.traverseDo ({ |elem, deepKeys|
 			var msgType;
-			if (deepKeys.last != \shared) {
+			// deepKeys.postcs;
+			if (isElemFunc.value(elem) and: { excludeKeys.includes(deepKeys.last).not }) {
 				MKtlDesc.fillMidiDefaults(elem);
 				msgType = elem[\midiMsgType];
 
 				if (msgType.notNil) {
 					msgTypesUsed.add(msgType.unbubble);
 				} {
-					//	"missing: ".post;
+					"missing: ".post;
+					elem.postcs;
 					missing.add(elem.elemKey);
 				};
 				// [elemKey, elem].postln;
 			};
-		}, MKtlDesc.isElemFunc);
+		}, isElemFunc);
 
+		if (msgTypesUsed.isEmpty) {
+			"*** % - msgTypesUsed are empty! % \n".postf(this, msgTypesUsed);
+		} {
+			// "% : msgTypesUsed are % \n".postf(this, msgTypesUsed);
+		};
 
 		// treat noteOnOff as noteOn / noteOff
 		if (msgTypesUsed.includes(\noteOnOff)) {

--- a/Modality/Classes/MKtl/MKtlDesc.sc
+++ b/Modality/Classes/MKtl/MKtlDesc.sc
@@ -423,14 +423,13 @@ MKtlDesc {
 		descFolders.do { |path, index|
 			var descDates, cacheDate;
 
-
 			descDates = MKtlDesc.findFile(folderIndex: index).collect(File.mtime(_));
 
 			if (File.exists(path +/+ MKtlDesc.cacheName)) {
 				cacheDate = File.mtime(path +/+ MKtlDesc.cacheName);
 			};
 
-			// write cahce files also when directory is empty
+			// write cache files also when directory is empty
 			// but not if empty directory already contains cache file
 			if (cacheDate.isNil or: {(descDates.maxItem ? -1) > cacheDate}) {
 				this.writeCache(index);
@@ -453,6 +452,7 @@ MKtlDesc {
 			var idInfo = desc.fullDesc.idInfo;
 			dictForFolder.put(filename, idInfo);
 		};
+
 		File.use(path, "w", { |file|
 			if (file.isOpen) {
 				file.write("Dictionary[\n");
@@ -650,6 +650,7 @@ MKtlDesc {
 			};
 		};
 	}
+
 
 
 	// creation methods

--- a/Modality/Classes/MKtl/MKtlDesc.sc
+++ b/Modality/Classes/MKtl/MKtlDesc.sc
@@ -38,7 +38,7 @@ MKtlDesc {
 		descFolders = List[defaultFolder, userFolder];
 		allDescs =();
 		isElemFunc = { |el|
-			el.isKindOf(Dictionary) and: { el[\elements].isNil }
+			el.isKindOf(Dictionary) and: { el.array.every(_ != \elements) }
 		};
 
 		fileToIDDict = Dictionary.new;
@@ -64,84 +64,71 @@ MKtlDesc {
 			noteOnVel: { |dict|
 				dict.putAll((\midiMsgType: \noteOn, \spec: \midiVel));
 			},
+			// pass if already expanded
+			elem: { |dict| dict },
 			// default
 			noteOnOff: { |dict|
-				var shared = ().putAll(dict);
-				dict.clear.putAll((
-					shared: shared,
+				dict.putAll((
 					\shareGui: true,
 					\elements: [
-						(key: \on,  midiMsgType: \noteOn,  spec: \midiVel),
-						(key: \off, midiMsgType: \noteOff, spec: \midiBut,
-							elementType: \padUp)
+						(key: \on,  midiMsgType: \noteOn,  spec: \midiVel, groupType: \elem),
+						(key: \off, midiMsgType: \noteOff, spec: \midiBut, elementType: \padUp, groupType: \elem)
 				]));
 			},
 			// others
 			noteOnOffBut: { |dict|
-				var shared = ().putAll(dict);
-				dict.clear.putAll((
-					shared: shared,
+				dict.putAll((
 					\shareGui: true,
 					\elements: [
-						(key: \on,  midiMsgType: \noteOn,  spec: \midiBut),
-						(key: \off, midiMsgType: \noteOff, spec: \midiBut, elementType: \padUp)
+						(key: \on,  midiMsgType: \noteOn,  spec: \midiBut, groupType: \elem),
+						(key: \off, midiMsgType: \noteOff, spec: \midiBut, elementType: \padUp, groupType: \elem)
 				]));
 			},
 			noteOnOffVel: { |dict|
-				var shared = ().putAll(dict);
-				dict.clear.putAll((
-					shared: shared,
+				dict.putAll((
 					\shareGui: true,
 					\elements: [
-						(key: \on,  midiMsgType: \noteOn,  spec: \midiVel),
-						(key: \off, midiMsgType: \noteOff, spec: \midiVel, elementType: \padUp)
+						(key: \on,  midiMsgType: \noteOn,  spec: \midiVel, groupType: \elem),
+						(key: \off, midiMsgType: \noteOff, spec: \midiVel, elementType: \padUp, groupType: \elem)
 				]));
 			},
 			noteOnOffTouch: { |dict|
-				var shared = ().putAll(dict);
-				dict.clear.putAll((
-					shared: shared,
+				dict.putAll((
 					\shareGui: true,
 					\elements: [
-						(key: \on,  midiMsgType: \noteOn,  spec: \midiVel),
-						(key: \off, midiMsgType: \noteOff, spec: \midiBut, elementType: \padUp),
-						(key: \touch, midiMsgType: \polytouch, spec: \midiVel, elementType: \padMove)
+						(key: \on,  midiMsgType: \noteOn,  spec: \midiVel, groupType: \elem),
+						(key: \off, midiMsgType: \noteOff, spec: \midiBut, elementType: \padUp, groupType: \elem),
+						(key: \touch, midiMsgType: \polytouch, spec: \midiVel, elementType: \padMove, groupType: \elem)
 				]));
 			},
 			noteOnOffVelTouch: { |dict|
-				var shared = ().putAll(dict);
-				dict.clear.putAll((
-					shared: shared,
+				dict.putAll((
 					\shareGui: true,
 					\elements: [
 						(key: \on,  midiMsgType: \noteOn,  spec: \midiVel),
-						(key: \off, midiMsgType: \noteOff, spec: \midiVel, elementType: \padUp),
-						(key: \touch, midiMsgType: \polytouch, spec: \midiVel, elementType: \padMove)
+						(key: \off, midiMsgType: \noteOff, spec: \midiVel, elementType: \padUp, groupType: \elem),
+						(key: \touch, midiMsgType: \polytouch, spec: \midiVel, elementType: \padMove, groupType: \elem)
 				]));
 			},
 			// fader touch on/off + control
 			// steinberg CMC uses this
 			noteOnOffButCtl: { |dict|
-				var shared = ().putAll(dict);
-				dict.clear.putAll((
-					shared: shared,
+				dict.putAll((
 					\shareGui: true,
 					\elements: [
 						(key: \on,  midiMsgType: \noteOn,  spec: \midiBut),
-						(key: \off, midiMsgType: \noteOff, spec: \midiBut, elementType: \padUp),
-						(key: \ctl, midiMsgType: \control, spec: \midiVel, elementType: \padMove)
+						(key: \off, midiMsgType: \noteOff, spec: \midiBut, elementType: \padUp, groupType: \elem),
+						(key: \ctl, midiMsgType: \control, spec: \midiVel, elementType: \padMove, groupType: \elem)
 				]));
 			},
 			// velocity on, but off, pressure -> control
 			noteOnOffCtl: { |dict|
-				var shared = ().putAll(dict);
-				dict.clear.putAll((
-					shared: shared,
+				dict.putAll((
 					\shareGui: true,
 					\elements: [
 						(key: \on,  midiMsgType: \noteOn,  spec: \midiVel),
-						(key: \off, midiMsgType: \noteOff, spec: \midiBut, elementType: \padUp),
-						(key: \ctl, midiMsgType: \control, spec: \midiVel, elementType: \padMove)
+						(key: \off, midiMsgType: \noteOff, spec: \midiBut, elementType: \padUp, groupType: \elem),
+						(key: \ctl, midiMsgType: \control, spec: \midiVel, elementType: \padMove, groupType: \elem)
 				]));
 			},
 		);
@@ -172,9 +159,10 @@ MKtlDesc {
 
 		groupFunc.value(dict);
 		dict.put(\groupType, groupType);
-		dict.elements.do { |elemDict|
-			elemDict.style = dict.style;
-		};
+		this.makeParents(dict);
+		// dict.elements.do { |elemDict|
+		// 	elemDict.style = dict.style;
+		// };
 		^dict;
 	}
 

--- a/Modality/Classes/MKtl/MKtlDesc.sc
+++ b/Modality/Classes/MKtl/MKtlDesc.sc
@@ -1015,12 +1015,12 @@ MKtlDesc {
 			// "% : msgTypesUsed are % \n".postf(this, msgTypesUsed);
 		};
 
-		// treat noteOnOff as noteOn / noteOff
-		if (msgTypesUsed.includes(\noteOnOff)) {
-			msgTypesUsed.add(\noteOn);
-			msgTypesUsed.add(\noteOff);
-			msgTypesUsed.remove(\noteOnOff);
-		};
+		// // treat noteOnOff as noteOn / noteOff
+		// if (msgTypesUsed.includes(\noteOnOff)) {
+		// 	msgTypesUsed.add(\noteOn);
+		// 	msgTypesUsed.add(\noteOff);
+		// 	msgTypesUsed.remove(\noteOnOff);
+		// };
 
 		fullDesc.put(\msgTypesUsed, msgTypesUsed.asArray.sort);
 

--- a/Modality/Classes/MKtl/MKtlDesc.sc
+++ b/Modality/Classes/MKtl/MKtlDesc.sc
@@ -255,7 +255,9 @@ MKtlDesc {
 	*loadDescs { |filename = "*", folderIndex, post = false|
 		var paths = this.findFile(filename, folderIndex);
 		var descs = paths.collect {|path|
-			try { this.fromPath(path); };
+			try { this.fromPath(path); } {
+				"*** % FAILED: %\n".postf(path);
+			};
 		}.select(_.notNil);
 
 		if (post) {
@@ -884,7 +886,7 @@ MKtlDesc {
 		var postOne = { |elemOrGroup, index, depth = 0|
 			depth.do { $\t.post; };
 			index.post; $\t.post;
-			if (elemOrGroup[\elements].notNil) {
+			if (isElemFunc.value(elemOrGroup).not) {
 				"Group: ".post; elemOrGroup.key.postcs;
 				elemOrGroup[\elements].do({ |item, i|
 					postOne.value(item, i, depth + 1)

--- a/Modality/Classes/MKtl/MKtlElementGroup.sc
+++ b/Modality/Classes/MKtl/MKtlElementGroup.sc
@@ -68,6 +68,11 @@ MKtlElementGroup : MKtlElement {
 	shared_ { |dict| elemDesc = dict }
 	shared { ^elemDesc }
 
+	// do nothing, to avoid confusing "deviceSpec for 'nil' is missing" posts!
+	setSpecFromDesc {
+
+	}
+
 	// do we still need init?
 	// *  elements_ should do fromDesc a level lower!
 	init {

--- a/Modality/Classes/MKtl/MKtlElementGroup.sc
+++ b/Modality/Classes/MKtl/MKtlElementGroup.sc
@@ -16,28 +16,31 @@ MKtlElementGroup : MKtlElement {
 	}
 
 	*fromDesc { |desc, srcMktl|
-		var elems, isElem, group, elemKey;
+		var elems, isGroup, group, elemKey;
 		var mktlElemDict = srcMktl !? { srcMktl.elementsDict };
 		var newElem;
 
 		^if (desc.isKindOf(Dictionary)) {
-			elems = desc[\elements];
-			isElem = elems.isNil;
-			if (isElem) {
+			// "fromDesc: %\n".postf(desc.key);
+			// are there elements at this level, NOT IN PARENT or proto?
+			isGroup = desc.array.includes(\elements);
+
+			if (isGroup.not) {
 				elemKey = desc.elemKey;
 				newElem = MKtlElement(elemKey, desc, srcMktl);
 				mktlElemDict !? { mktlElemDict.put(elemKey, newElem) };
 				newElem;
 			} {
-				// elements is always an array
-				elems = elems.collect { |desc2|
+				////// elements is always an array
+				elems = desc[\elements].collect { |desc2|
 					this.fromDesc(desc2, srcMktl);
 				};
 				group = MKtlElementGroup(desc.key, srcMktl, elems);
 
-				if (desc[\shared].notNil) {
-					group.shared = desc[\shared];
-				};
+				group.elemDesc = desc;
+				// if (desc[\shared].notNil) {
+				// 	group.shared = desc[\shared];
+				// };
 
 				group.useSingleGui = desc.useSingleGui ? false;
 				group.groupType = desc.groupType;

--- a/Modality/Classes/TestClasses/TestMKtlDesc.sc
+++ b/Modality/Classes/TestClasses/TestMKtlDesc.sc
@@ -1,0 +1,264 @@
+/*
+TestMKtlDesc.findTestMethods.do { |meth| TestMKtlDesc.new.runTestMethod(meth) };
+
+TestMKtlDesc.runTest("TestMKtlDesc:test_makeParents");
+TestMKtlDesc.runTest("TestMKtlDesc:test_makeParents2");
+TestMKtlDesc.runTest("TestMKtlDesc:test_expandNoteOnOffCtl");
+
+// only in latest
+TestMKtlDesc.prRunAllTestMethods;
+*/
+
+// test well-formedness of MKtls
+TestMKtlDesc : UnitTest {
+
+	test_makeParents {
+		var elemDesc = (
+			key: \top,
+			extra: \info,
+			shared: (ding: \dong),
+			elements: { () }.dup(8)
+		);
+
+		// MKtlDesc.setParentAndShared(elemDesc);
+		MKtlDesc.makeParents(elemDesc);
+
+		this.assertEquals(elemDesc.elements[0].parent, (extra: \info, ding: \dong),
+			"element parent should contain merged enclosing dict and its 'shared' dict.", false);
+
+		// this.assert(elemDesc.elements[0].proto === elemDesc.shared,
+		// "element proto should be its containing elementDesc's shared dict.");
+
+		// this.assert(false, "false alarm, haha...");
+	}
+
+	test_makeParents2 {
+		var testElement;
+		var elemDesc = (
+			key: \top,
+			extra: \info,
+			shared: (ding: \dong),
+			elements: [
+				(key: \clink, a: \a, shared: (dinky: \kinky), elements: { () }.dup(8)),
+				(key: \clonk, b: \b, shared: (donky: \konky), elements: { () }.dup(8)),
+			]
+		);
+
+		MKtlDesc.makeParents(elemDesc);
+
+		testElement = elemDesc.elements[1].elements[4];
+		this.assertEquals(testElement.parent.parent, ( ding: \dong, extra: \info ),
+			"deeper element's parent's parent should contain merged top dict and and its 'shared' dict.",
+			false
+		);
+
+		// clear top parent so == works
+		testElement.parent.parent = nil;
+
+		this.assertEquals(elemDesc.elements[1].elements[4].parent, (b: \b, donky: \konky),
+			"deeper element's parent should contain merged enclosing dict and its 'shared' dict.",
+			false
+		);
+	}
+
+	// does not work:
+	test_testDesc {
+		var d = (
+			descName: 'testDesc',
+			deviceName: "testDesc",
+			protocol: 'midi',
+			idInfo: "testDesc",
+			elementsDesc: (
+				// not shared: (), but direct
+				elementType: \pad,
+				midiChan: 0,
+				midiMsgType: \noteOn,
+
+				elements: (48..55).collect { |midiNum, i|
+					( midiNum: midiNum )
+				}
+			)
+		);
+
+		MKtlDesc.fromDict(d);
+
+		this.assertEquals(d.elementsDesc.elements.size, 8,
+			"basic desc should have 8 elements.", false);
+
+		this.assertEquals(d.elementsDesc.elements[4].midiMsgType, \noteOn,
+			"basic desc should know midiMsgType from parent.", false);
+		// check parenthood
+		this.assertEquals(
+			d.elementsDesc.elements[0].parent,
+			(elementType: \pad, midiChan: 0, midiMsgType: \noteOn),
+			"parent of basic desc element should be desc-dict.", false);
+
+		// cleanup
+		MKtlDesc.allDescs.removeAt('testDesc');
+	}
+
+	//// works, but should complain
+	test_testDescShared {
+		var d = (
+			descName: 'testDesc',
+			deviceName: "testDesc",
+			protocol: 'midi',
+			idInfo: "testDesc",
+			elementsDesc: (
+				shared: (
+					elementType: \pad,
+					midiChan: 0,
+					midiMsgType: \noteOn
+				),
+				elements: (48..55).collect { |midiNum, i|
+					( midiNum: midiNum )
+				}
+			)
+		);
+
+		MKtlDesc.fromDict(d);
+
+		this.assertEquals(d.elementsDesc.elements[4].midiMsgType, \noteOn,
+			"basic desc should know midiMsgType from parent's shared dict.", false);
+		// check parenthood
+		this.assertEquals(
+			d.elementsDesc.elements[0].parent,
+			(elementType: \pad, midiChan: 0, midiMsgType: \noteOn),
+			"parent of basic desc element should be desc-dict.", false);
+
+		// cleanup
+		MKtlDesc.allDescs.removeAt('testDesc');
+	}
+
+	test_expand_noteOnOff {
+		var dict = (
+			descName: 'testDesc',
+			deviceName: "testDesc",
+			protocol: 'midi',
+			idInfo: "testDesc",
+			elementsDesc: (
+				elementType: \pad,
+				midiChan: 0,
+				style: (thisIS: \style),
+				groupType: \noteOnOff,
+				elements: (48..55).collect { |midiNum, i|
+					( midiNum: midiNum )
+				}
+			)
+		);
+
+		var desc = MKtlDesc.fromDict(dict);
+
+		this.assertEquals(
+			desc.elementsDesc.elements[0].elements.collect(_.midiMsgType),
+			[\noteOn, \noteOff],
+			"expanded noteOnOff desc elements should have proper midiMsgTypes.", false);
+
+		// cleanup
+		MKtlDesc.allDescs.removeAt('testDesc');
+	}
+
+	test_expand_noteOnOffBut {
+		var dict = (
+			descName: 'testDesc',
+			deviceName: "testDesc",
+			protocol: 'midi',
+			idInfo: "testDesc",
+			elementsDesc: (
+				elementType: \pad,
+				midiChan: 0,
+				style: (thisIS: \style),
+				groupType: \noteOnOffBut,
+				elements: (48..55).collect { |midiNum, i|
+					( midiNum: midiNum )
+				}
+			)
+		);
+
+		var desc = MKtlDesc.fromDict(dict);
+
+		this.assertEquals(
+			desc.elementsDesc.elements[0].elements.collect(_.midiMsgType),
+			[\noteOn, \noteOff],
+			"expanded noteOnOff desc elements should have proper midiMsgTypes.", false);
+
+		// cleanup
+		MKtlDesc.allDescs.removeAt('testDesc');
+	}
+
+
+	test_expand_noteOnOffCtl {
+		var dict = (
+			descName: 'testDesc',
+			deviceName: "testDesc",
+			protocol: 'midi',
+			idInfo: "testDesc",
+			elementsDesc: (
+				elementType: \pad,
+				midiChan: 0,
+				style: (thisIS: \style),
+				groupType: \noteOnOffCtl,
+				elements: (48..55).collect { |midiNum, i|
+					( midiNum: midiNum )
+				}
+			)
+		);
+
+		var desc = MKtlDesc.fromDict(dict);
+
+		this.assertEquals(
+			desc.elementsDesc.elements[0].elements.collect(_.midiMsgType).postcs,
+			[\noteOn, \noteOff, \control],
+			"expanded noteOnOff desc elements should have proper midiMsgTypes.", false);
+
+		// cleanup
+		MKtlDesc.allDescs.removeAt('testDesc');
+	}
+
+	test_expand_noteOnOffTouch {
+		var dict = (
+			descName: 'testDesc',
+			deviceName: "testDesc",
+			protocol: 'midi',
+			idInfo: "testDesc",
+			elementsDesc: (
+				elementType: \pad,
+				midiChan: 0,
+				style: (thisIS: \style),
+				groupType: \noteOnOffTouch,
+				elements: (48..55).collect { |midiNum, i|
+					( midiNum: midiNum )
+				}
+			)
+		);
+
+		var desc = MKtlDesc.fromDict(dict);
+
+		this.assertEquals(
+			desc.elementsDesc.elements[0].elements.collect(_.midiMsgType).postcs,
+			[\noteOn, \noteOff, \polytouch],
+			"expanded noteOnOff desc elements should have proper midiMsgTypes.", false);
+
+		// cleanup
+		MKtlDesc.allDescs.removeAt('testDesc');
+	}
+
+	//////// not really a UnitTest, more a big load test:
+	//////// All desc files should load without failures or complaints
+	test_loadDescs {
+		// only test default folder
+		var paths, pathNames, loadedNames, nonLoaded, numPaths;
+		paths = MKtlDesc.findFile("*", 0);
+		pathNames = paths.collect { |path| path.basename.split($.)[0].asSymbol };
+		MKtlDesc.loadDescs("*", 0);
+		loadedNames = MKtlDesc.allDescs.keys(Array).sort;
+		// empty if every desc file was loaded as a desk
+		nonLoaded = pathNames.difference(loadedNames);
+
+		this.assert(nonLoaded.isEmpty,
+			"all % desc.scd files should become a loaded desc object.".format(paths.size)
+		);
+		// cleanup
+		MKtlDesc.allDescs.clear;
+	}
+}

--- a/Modality/Classes/TestClasses/TestMKtlDesc.sc
+++ b/Modality/Classes/TestClasses/TestMKtlDesc.sc
@@ -207,7 +207,7 @@ TestMKtlDesc : UnitTest {
 		var desc = MKtlDesc.fromDict(dict);
 
 		this.assertEquals(
-			desc.elementsDesc.elements[0].elements.collect(_.midiMsgType).postcs,
+			desc.elementsDesc.elements[0].elements.collect(_.midiMsgType),
 			[\noteOn, \noteOff, \control],
 			"expanded noteOnOff desc elements should have proper midiMsgTypes.", false);
 
@@ -235,7 +235,7 @@ TestMKtlDesc : UnitTest {
 		var desc = MKtlDesc.fromDict(dict);
 
 		this.assertEquals(
-			desc.elementsDesc.elements[0].elements.collect(_.midiMsgType).postcs,
+			desc.elementsDesc.elements[0].elements.collect(_.midiMsgType),
 			[\noteOn, \noteOff, \polytouch],
 			"expanded noteOnOff desc elements should have proper midiMsgTypes.", false);
 

--- a/Modality/MKtlDescriptions/ableton-push-2.desc.scd
+++ b/Modality/MKtlDescriptions/ableton-push-2.desc.scd
@@ -48,7 +48,7 @@ elementsDesc: (
 							shared: (
 								elementType: 'button', spec: \midiVel,
 								midiNum: num,
-								style: (row: -0.5, column: i + 2, height: 0.7)
+								style: (row: -0.1, column: i + 2, height: 0.7)
 							)
 						),
 						(
@@ -56,48 +56,25 @@ elementsDesc: (
 							midiNum: 71+num,
 							midiMsgType: \cc, elementType: \encoder,
 							spec: \midiCC,
-							style: (row: 0, column: 2 + i)
+							style: (row: 0.5, column: 2 + i)
 						)
 					]
 				)
 			}
-
-
-			// [
-			// 	(
-			// 		key: \touch,
-			// 		shared: (
-			// 			elementType: 'button', spec: \midiVel,
-			// 			groupType: \noteOnOffBut,
-			// 		),
-			// 		elements: ( 0.. 8 ).collect { |num, i|
-			// 			(
-			// 				key: (num+1).asSymbol,
-			// 				shared: (
-			// 					midiNum: num,
-			// 					style: (row: -0.5, column: i + 2, height: 0.7)
-			// 				)
-			// 			)
-			// 		}
-			// 	),
-			// 	(
-			// 		key: \turn,
-			// 		shared: (midiMsgType: \cc, elementType: \encoder, spec: \midiCC),
-			// 		elements: (71..79).collect { |num, i|
-			// 			(midiNum: num, style: (row: 0, column: 2 + i))
-			// 		}
-			// 	)
-			// ]
 		),
 		//------ pads -------------
 		(
 			key: \pad,
-			shared: (elementType: \pad, groupType: \noteOnOffTouch, ioType: \inout),
+			elementType: \pad,
+			ioType: \inout,
 			elements: (36..99).clump(8).reverse.collect { |rownums, i|
 				(
 					elements: rownums.collect { |num, j|
 						(
-							shared: (midiNum: num, style: (row: i + 4, column: j + 2))
+
+							midiNum: num,
+							groupType: \noteOnOffTouch,
+							style: (row: i + 4, column: j + 2)
 						)
 					}
 				)
@@ -186,9 +163,7 @@ elementsDesc: (
 					elements: row.collect { |num, j|
 						(
 							midiNum: num,
-							shared: (
-								style: (row: i * 0.5 + 3, column: j + 2, height: 0.6)
-							)
+							style: (row: i * 0.5 + 3, column: j + 2, height: 0.6)
 						)
 					}
 				)

--- a/Modality/MKtlDescriptions/ableton-push.desc.scd
+++ b/Modality/MKtlDescriptions/ableton-push.desc.scd
@@ -1,5 +1,8 @@
 /*
-MKtlDesc.loadDescs("*push"); m.free; m = MKtl(\push, "*push").trace; m.gui;
+MKtlDesc.loadDescs("*push"); m.free; m = MKtl(\push, "*push").trace;
+m.gui;
+m.elAt(\pad, 0, 0).elemDesc.style.parent
+
 */
 (
 deviceName: "Ableton Push",
@@ -50,242 +53,214 @@ elementsDesc: (
 						(
 							key: \touch,
 							groupType: \noteOnOffBut,
-							shared: (
-								elementType: 'button', spec: \midiVel,
-								midiNum: num,
-								style: (row: -0.5, column: i + 2, height: 0.7)
-							)
+							elementType: 'button', spec: \midiVel,
+							midiNum: num,
+							// style: (row: 0, column: i + 2, height: 0.7)
+
 						),
 						(
 							key: \turn,
 							midiNum: 71+num,
 							midiMsgType: \cc, elementType: \encoder,
 							spec: \midiCC,
-							style: (row: 0, column: 2 + i)
+							// style: (row: 0.5, column: 2 + i)
 						)
 					]
 				)
 			}
-
-
-			// [
-			// 	(
-			// 		key: \touch,
-			// 		shared: (
-			// 			elementType: 'button', spec: \midiVel,
-			// 			groupType: \noteOnOffBut,
-			// 		),
-			// 		elements: ( 0.. 8 ).collect { |num, i|
-			// 			(
-			// 				key: (num+1).asSymbol,
-			// 				shared: (
-			// 					midiNum: num,
-			// 					style: (row: -0.5, column: i + 2, height: 0.7)
-			// 				)
-			// 			)
-			// 		}
-			// 	),
-			// 	(
-			// 		key: \turn,
-			// 		shared: (midiMsgType: \cc, elementType: \encoder, spec: \midiCC),
-			// 		elements: (71..79).collect { |num, i|
-			// 			(midiNum: num, style: (row: 0, column: 2 + i))
-			// 		}
-			// 	)
-			// ]
 		),
 		//------ pads -------------
-		(
-			key: \pad,
-			shared: (elementType: \pad, groupType: \noteOnOffTouch, ioType: \inout),
-			elements: (36..99).clump(8).reverse.collect { |rownums, i|
-				(
-					elements: rownums.collect { |num, j|
-						(
-							shared: (midiNum: num, style: (row: i + 4, column: j + 2))
-						)
-					}
-				)
-			}
-		),
-		//------ ribbon -----------
-		(
-			key: \ribbon,
-			elements: [
-				(
-					key: \touch,
-					groupType: \noteOnOffBut,
-					shared: (
-						midiNum: 12,
-						groupType: \noteOnOffBut,
-						elementType: 'pad',
-						midiChan: 0,
-						spec: 'midiBut',
-						style: (row: 4, column: 1)
-					)
-				),
-				(
-					key: \bend,
-					midiMsgType: 'bend',
-					elementType: 'ribbon',
-					spec: 'midiBend',
-					style: (row: 5, column: 1, height: 7)
-				)
-			]
-		),
-		//------ side encoders (not in a group because very different in experience)
-		(
-			key: \knLeft,
-			elements: [
-				(
-					key: \touch,
-					groupType: \noteOnOffBut,
-					shared: (
-						midiNum: 10,
-						elementType: \pad, groupType: \noteOnOffBut,
-						spec: \midiVel,
-						style: (row: 3, column: 0, height: 0.4)
-					),
-				),
-				(
-					key: \turn,
-					midiMsgType: \cc,
-					elementType: \encoder,
-					midiNum: 14,
-					spec: \midiBut,
-					style: (row: 3.4, column: 0, height: 0.8)
-				)
-			]
-		),
-		(
-			key: \knRight,
-			elements: [
-				(
-					key: \touch,
-					groupType: \noteOnOffBut,
-					shared: (
-						midiNum: 9,
-						elementType: \pad, groupType: \noteOnOffBut,
-						spec: \midiVel,
-						style: (row: 3, column: 1, height: 0.4)
-					),
-				),
-				(
-					key: \turn,
-					midiMsgType: \cc,
-					elementType: \encoder,
-					midiNum: 15,
-					spec: \midiBut,
-					style: (row: 3.4, column: 1, height: 0.8)
-				)
-			]
-		),
-		//------ color button rows
-		(
-			key: \bt,
-			shared: (midiMsgType: 'cc', elementType: 'pad',
-				spec: 'midiCC', ioType: \inout),
-			elements: [(20..27), (102..109)].collect { |row, i|
-				(
-					// shared: (groupType: \noteOnOffBut),
-					elements: row.collect { |num, j|
-						(
-							midiNum: num,
-							shared: (
-								style: (row: i * 0.5 + 3, column: j + 2, height: 0.6)
-							)
-						)
-					}
-				)
-			}
-		),
-		//------ note length buttons
-
-		(
-			key: \btLen,
-			shared: (midiMsgType: 'cc', elementType: 'button',
-				spec: 'midiCC', ioType: \inout),
-			elements: [
-				(key: '132t', midiNum: 43, style: (row: 4, column: 10)),
-				(key: '132',  midiNum: 42, style: (row: 5, column: 10)),
-				(key: '116t', midiNum: 41, style: (row: 6, column: 10)),
-				(key: '116',  midiNum: 40, style: (row: 7, column: 10)),
-				(key: '18t',  midiNum: 39, style: (row: 8, column: 10)),
-				(key: '18',   midiNum: 38, style: (row: 9, column: 10)),
-				(key: '14t',  midiNum: 37, style: (row: 10, column: 10)),
-				(key: '14',   midiNum: 36, style: (row: 11,column: 10))
-			]
-		),
-		// // ------ ctl buttons
-		(
-			key: \btCtl,
-			shared: (midiMsgType: 'cc', elementType: 'button',
-				spec: 'midiCC', ioType: \inout),
-			elements: [
-				(key: \tapTempo, midiNum: 3, style: (row: 1, column: 0)),
-				(key: \metronome, midiNum: 9, style: (row: 2, column: 0, height: 0.7)),
-
-				(key: \undo, 	midiNum: 119, style: (row: 4, column: 0, height: 0.8)),
-				(key: \delete, 	midiNum: 118, style: (row: 4.7, column: 0, height: 0.8)),
-				(key: \double, 	midiNum: 117, style: (row: 5.4, column: 0, height: 0.8)),
-				(key: \quantize, midiNum: 116, style: (row: 6.1, column: 0, height: 0.8)),
-
-				(key: \fixedLength, midiNum: 90, style: (row: 7, column: 0, height: 0.8)),
-				(key: \automation,  midiNum: 89, style: (row: 7.7, column: 0, height: 0.8)),
-				(key: \duplicate,   midiNum: 88, style: (row: 8.4, column: 0, height: 0.8)),
-				(key: \new, 		midiNum: 87, style: (row: 9, column: 0)),
-				(key: \record, 		midiNum: 86, style: (row: 10, column: 0)),
-				(key: \play, 		midiNum: 85, style: (row: 11, column: 0)),
-
-				(key: \master, 		midiNum: 28, style: (row: 3.0, column: 10, height: 0.6)),
-				(key: \stop, 		midiNum: 29, style: (row: 3.5, column: 10, height: 0.6)),
-
-
-				(key: \volume, 	midiNum: 114, style: (row: 1.0, column: 11, height: 0.8)),
-				(key: \track, 	midiNum: 112, style: (row: 1.6, column: 11, height: 0.8)),
-				(key: \device, 	midiNum: 110, style: (row: 2.2, column: 11, height: 0.8)),
-
-				(key: \in, 		midiNum:  62, style: (row: 3.0, column: 11, height: 0.8)),
-				(key: \mute, 	midiNum:  60, style: (row: 3.6, column: 11, height: 0.8)),
-				(key: \scales, 	midiNum:  58, style: (row: 4.2, column: 11, height: 0.8)),
-				(key: \repeat, 	midiNum:  56, style: (row: 4.8, column: 11, height: 0.8)),
-				(key: \octaveDown,midiNum:54, style: (row: 5.4, column: 11, height: 0.8)),
-
-				(key: \addEffect,midiNum:52, style:(row: 7.0, column: 11, height: 0.8)),
-				(key: \note, 	midiNum: 50, style: (row: 7.6, column: 11, height: 0.8)),
-				(key: \select, 	midiNum: 48, style: (row: 8.2, column: 11, height: 0.8)),
-
-				(key: \panSend, midiNum: 115, style: (row: 1.0, column: 12, height: 0.8)),
-				(key: \clip, 	midiNum: 113, style: (row: 1.6, column: 12, height: 0.8)),
-				(key: \browse, 	midiNum: 111, style: (row: 2.2, column: 12, height: 0.8)),
-
-				(key: \out, 	midiNum: 63, style: (row: 3.0, column: 12, height: 0.8)),
-				(key: \solo, 	midiNum: 61, style: (row: 3.6, column: 12, height: 0.8)),
-				(key: \user, 	midiNum: 59, style: (row: 4.2, column: 12, height: 0.8)),
-				(key: \accent, 	midiNum: 57, style: (row: 4.8, column: 12, height: 0.8)),
-				(key: \octaveUp,midiNum: 55, style: (row: 5.4, column: 12, height: 0.8)),
-
-				(key: \addTrack,midiNum: 53, style: (row: 7.0, column: 12, height: 0.8)),
-				(key: \session, midiNum: 51, style: (row: 7.6, column: 12, height: 0.8)),
-				(key: \shift, 	midiNum: 49, style: (row: 8.2, column: 12, height: 0.8)),
-
-				(key: \left, 	midiNum: 44, style: (row: 9.8, column: 11, height: 0.8)),
-				(key: \right, 	midiNum: 45, style: (row: 9.8, column: 12, height: 0.8)),
-				(key: \up, 		midiNum: 46, style: (row: 9.2, column: 11.5, height: 0.8)),
-				(key: \down, 	midiNum: 47, style: (row: 10.4, column: 11.5, height: 0.8))
-			]
-		),
-		(
-			key: \pedal,
-			shared: (midiMsgType: 'cc', elementType: 'button',
-				spec: 'midiCC', ioType: \in
-			),
-			elements: [
-				(key: '1', midiNum: 64, style: (row: 11, column: 11)),
-				(key: '2', midiNum: 69, style: (row: 11, column: 12))
-			]
-
-		)
+		// (
+		// 	key: \pad,
+		// 	elementType: \pad,
+		//
+		// 	ioType: \inout,
+		// 	elements: (36..99).clump(8).reverse.collect { |rownums, i|
+		// 		(
+		// 			elements: rownums.collect { |num, j|
+		// 				(
+		// 					groupType: \noteOnOffTouch,
+		// 					midiNum: num,
+		// 					style: (row: i + 4, column: j + 2)
+		// 				)
+		// 			}
+		// 		)
+		// 	}
+		// ),
+		// //------ ribbon -----------
+		// (
+		// 	key: \ribbon,
+		// 	elements: [
+		// 		(
+		// 			key: \touch,
+		// 			groupType: \noteOnOffBut,
+		// 			midiNum: 12,
+		// 			elementType: 'pad',
+		// 			midiChan: 0,
+		// 			spec: 'midiBut',
+		// 			style: (row: 4, column: 1)
+		//
+		// 		),
+		// 		(
+		// 			key: \bend,
+		// 			midiMsgType: 'bend',
+		// 			elementType: 'ribbon',
+		// 			spec: 'midiBend',
+		// 			style: (row: 5, column: 1, height: 7)
+		// 		)
+		// 	]
+		// ),
+		// //------ side encoders (not in a group because very different in experience)
+		// (
+		// 	key: \knLeft,
+		// 	elements: [
+		// 		(
+		// 			key: \touch,
+		// 			groupType: \noteOnOffBut,
+		// 			shared: (
+		// 				midiNum: 10,
+		// 				elementType: \pad, groupType: \noteOnOffBut,
+		// 				spec: \midiVel,
+		// 				style: (row: 3, column: 0, height: 0.4)
+		// 			),
+		// 		),
+		// 		(
+		// 			key: \turn,
+		// 			midiMsgType: \cc,
+		// 			elementType: \encoder,
+		// 			midiNum: 14,
+		// 			spec: \midiBut,
+		// 			style: (row: 3.4, column: 0, height: 0.8)
+		// 		)
+		// 	]
+		// ),
+		// (
+		// 	key: \knRight,
+		// 	elements: [
+		// 		(
+		// 			key: \touch,
+		// 			groupType: \noteOnOffBut,
+		// 			shared: (
+		// 				midiNum: 9,
+		// 				elementType: \pad, groupType: \noteOnOffBut,
+		// 				spec: \midiVel,
+		// 				style: (row: 3, column: 1, height: 0.4)
+		// 			),
+		// 		),
+		// 		(
+		// 			key: \turn,
+		// 			midiMsgType: \cc,
+		// 			elementType: \encoder,
+		// 			midiNum: 15,
+		// 			spec: \midiBut,
+		// 			style: (row: 3.4, column: 1, height: 0.8)
+		// 		)
+		// 	]
+		// ),
+		// //------ color button rows
+		// (
+		// 	key: \bt,
+		// 	shared: (midiMsgType: 'cc', elementType: 'pad',
+		// 	spec: 'midiCC', ioType: \inout),
+		// 	elements: [(20..27), (102..109)].collect { |row, i|
+		// 		(
+		// 			// shared: (groupType: \noteOnOffBut),
+		// 			elements: row.collect { |num, j|
+		// 				(
+		// 					midiNum: num,
+		// 					style: (row: i * 0.5 + 3, column: j + 2, height: 0.6)
+		// 				)
+		// 			}
+		// 		)
+		// 	}
+		// ),
+		// //------ note length buttons
+		//
+		// (
+		// 	key: \btLen,
+		// 	shared: (midiMsgType: 'cc', elementType: 'button',
+		// 	spec: 'midiCC', ioType: \inout),
+		// 	elements: [
+		// 		(key: '132t', midiNum: 43, style: (row: 4, column: 10)),
+		// 		(key: '132',  midiNum: 42, style: (row: 5, column: 10)),
+		// 		(key: '116t', midiNum: 41, style: (row: 6, column: 10)),
+		// 		(key: '116',  midiNum: 40, style: (row: 7, column: 10)),
+		// 		(key: '18t',  midiNum: 39, style: (row: 8, column: 10)),
+		// 		(key: '18',   midiNum: 38, style: (row: 9, column: 10)),
+		// 		(key: '14t',  midiNum: 37, style: (row: 10, column: 10)),
+		// 		(key: '14',   midiNum: 36, style: (row: 11,column: 10))
+		// 	]
+		// ),
+		// // // ------ ctl buttons
+		// (
+		// 	key: \btCtl,
+		// 	shared: (midiMsgType: 'cc', elementType: 'button',
+		// 	spec: 'midiCC', ioType: \inout),
+		// 	elements: [
+		// 		(key: \tapTempo, midiNum: 3, style: (row: 1, column: 0)),
+		// 		(key: \metronome, midiNum: 9, style: (row: 2, column: 0, height: 0.7)),
+		//
+		// 		(key: \undo, 	midiNum: 119, style: (row: 4, column: 0, height: 0.8)),
+		// 		(key: \delete, 	midiNum: 118, style: (row: 4.7, column: 0, height: 0.8)),
+		// 		(key: \double, 	midiNum: 117, style: (row: 5.4, column: 0, height: 0.8)),
+		// 		(key: \quantize, midiNum: 116, style: (row: 6.1, column: 0, height: 0.8)),
+		//
+		// 		(key: \fixedLength, midiNum: 90, style: (row: 7, column: 0, height: 0.8)),
+		// 		(key: \automation,  midiNum: 89, style: (row: 7.7, column: 0, height: 0.8)),
+		// 		(key: \duplicate,   midiNum: 88, style: (row: 8.4, column: 0, height: 0.8)),
+		// 		(key: \new, 		midiNum: 87, style: (row: 9, column: 0)),
+		// 		(key: \record, 		midiNum: 86, style: (row: 10, column: 0)),
+		// 		(key: \play, 		midiNum: 85, style: (row: 11, column: 0)),
+		//
+		// 		(key: \master, 		midiNum: 28, style: (row: 3.0, column: 10, height: 0.6)),
+		// 		(key: \stop, 		midiNum: 29, style: (row: 3.5, column: 10, height: 0.6)),
+		//
+		//
+		// 		(key: \volume, 	midiNum: 114, style: (row: 1.0, column: 11, height: 0.8)),
+		// 		(key: \track, 	midiNum: 112, style: (row: 1.6, column: 11, height: 0.8)),
+		// 		(key: \device, 	midiNum: 110, style: (row: 2.2, column: 11, height: 0.8)),
+		//
+		// 		(key: \in, 		midiNum:  62, style: (row: 3.0, column: 11, height: 0.8)),
+		// 		(key: \mute, 	midiNum:  60, style: (row: 3.6, column: 11, height: 0.8)),
+		// 		(key: \scales, 	midiNum:  58, style: (row: 4.2, column: 11, height: 0.8)),
+		// 		(key: \repeat, 	midiNum:  56, style: (row: 4.8, column: 11, height: 0.8)),
+		// 		(key: \octaveDown,midiNum:54, style: (row: 5.4, column: 11, height: 0.8)),
+		//
+		// 		(key: \addEffect,midiNum:52, style:(row: 7.0, column: 11, height: 0.8)),
+		// 		(key: \note, 	midiNum: 50, style: (row: 7.6, column: 11, height: 0.8)),
+		// 		(key: \select, 	midiNum: 48, style: (row: 8.2, column: 11, height: 0.8)),
+		//
+		// 		(key: \panSend, midiNum: 115, style: (row: 1.0, column: 12, height: 0.8)),
+		// 		(key: \clip, 	midiNum: 113, style: (row: 1.6, column: 12, height: 0.8)),
+		// 		(key: \browse, 	midiNum: 111, style: (row: 2.2, column: 12, height: 0.8)),
+		//
+		// 		(key: \out, 	midiNum: 63, style: (row: 3.0, column: 12, height: 0.8)),
+		// 		(key: \solo, 	midiNum: 61, style: (row: 3.6, column: 12, height: 0.8)),
+		// 		(key: \user, 	midiNum: 59, style: (row: 4.2, column: 12, height: 0.8)),
+		// 		(key: \accent, 	midiNum: 57, style: (row: 4.8, column: 12, height: 0.8)),
+		// 		(key: \octaveUp,midiNum: 55, style: (row: 5.4, column: 12, height: 0.8)),
+		//
+		// 		(key: \addTrack,midiNum: 53, style: (row: 7.0, column: 12, height: 0.8)),
+		// 		(key: \session, midiNum: 51, style: (row: 7.6, column: 12, height: 0.8)),
+		// 		(key: \shift, 	midiNum: 49, style: (row: 8.2, column: 12, height: 0.8)),
+		//
+		// 		(key: \left, 	midiNum: 44, style: (row: 9.8, column: 11, height: 0.8)),
+		// 		(key: \right, 	midiNum: 45, style: (row: 9.8, column: 12, height: 0.8)),
+		// 		(key: \up, 		midiNum: 46, style: (row: 9.2, column: 11.5, height: 0.8)),
+		// 		(key: \down, 	midiNum: 47, style: (row: 10.4, column: 11.5, height: 0.8))
+		// 	]
+		// ),
+		// (
+		// 	key: \pedal,
+		// 	shared: (midiMsgType: 'cc', elementType: 'button',
+		// 		spec: 'midiCC', ioType: \in
+		// 	),
+		// 	elements: [
+		// 		(key: '1', midiNum: 64, style: (row: 11, column: 11)),
+		// 		(key: '2', midiNum: 69, style: (row: 11, column: 12))
+		// 	]
+		//
+		// )
 	]
 )
 )

--- a/Modality/MKtlDescriptions/akai-lpd8.desc.scd
+++ b/Modality/MKtlDescriptions/akai-lpd8.desc.scd
@@ -9,7 +9,6 @@ MKtlDesc.loadDescs("*lpd8");
 // close old m, open new one, make gui:
 m.free; m = MKtl(\lpd8, "*lpd8"); m.gui;
 m.trace;
-m.elementsDict.size;
 m.postElements;
 */
 
@@ -19,10 +18,12 @@ m.postElements;
 // and how to play something with it.
 
 MKtl.find; // find all MDIDI devices and list them
-MKtl('lpd').clear;
+
+
+MKtlDesc.loadDescs("*lpd8"); // reload desc after changing this file?
+MKtl('lpd').free;
 MKtl('lpd', "*lpd8"); // make an MKtl for LPD8.
 MKtl('lpd').trace;
-
 // make a gui for it
 MKtl('lpd').gui;
 
@@ -69,7 +70,7 @@ protocol: \midi,
 deviceType: \drumpad,
 elementTypes: [\pad, \knob],
 status: (
-	osx: "tested and working, 2016_03_15, adc",
+	osx: "tested and working, 2019_12_29, adc",
 	linux: "tested and working 2016_03_20, nescivi",
 	win: "unknown"
 ),
@@ -92,24 +93,30 @@ deviceInfo: (
 elementsDesc: (
 	// key: \lpd8,
 	'shared': ( midiChan: 0),
+	\spec: \midiCC,
 	elements: [
 		(
 			key: \kn,
-			shared: (\elementType: \knob, \midiMsgType: \cc, \ioType: \in,
-				\spec: \midiCC),
+			\elementType: \knob,
+			\midiMsgType: \cc,
+			\ioType: \in,
+
 			elements: (1..8).collect { |num, i|
-				(key: num.asSymbol, \midiNum: num,
+				(	key: num.asSymbol, \midiNum: num,
 					style: (row: i div: 4, column: i % 4 + 4)
 				)
 			}
 		),
 		(
 			key: \pad,
-			shared: (\elementType: \pad, groupType: \noteOnOff, \ioType: \inout),
+			\elementType: \pad,
+			\ioType: \inout,
+
 			elements: (36..43).collect { |num, i|
-				(
-					key: (i+1).asSymbol,
-					shared: ( midiNum: num, style: (row: 1 - (i div: 4), column: i % 4))
+				(	key: (i+1).asSymbol,
+					groupType: \noteOnOff,
+					midiNum: num,
+					shared: (style: (row: 1 - (i div: 4), column: i % 4))
 				);
 			}
 		)

--- a/Modality/MKtlDescriptions/doepfer-pocketfader.desc.scd
+++ b/Modality/MKtlDescriptions/doepfer-pocketfader.desc.scd
@@ -5,6 +5,11 @@
 // For a usage example, see
 "Tutorials/Connecting_external_MIDI_devices".openHelpFile;
 
+thisProcess.nowExecutingPath.basename.split($.).first.postcs;
+
+d = MKtlDesc.loadDescs("*pocketfader").first;
+m.free; m = MKtl(\pf, "*pocketfader").trace.gui;
+
 */
 
 (

--- a/Modality/MKtlDescriptions/faderfox_uc4/faderfox-uc4.desc.scd
+++ b/Modality/MKtlDescriptions/faderfox_uc4/faderfox-uc4.desc.scd
@@ -40,8 +40,9 @@ parentDesc: "faderfox-uc4",
 
 status: (
 	linux: "unknown",
-	osx: "tested and working. 2016-03-16, adc",
-	win: "unknown"),
+	osx: "tested and working. 2019-12-29, adc",
+	win: "unknown"
+),
 
 elementsDesc: (
 	shared: (ioType: \inout),

--- a/Modality/MKtlDescriptions/faderfox_uc4/faderfox-uc4_pg.desc.scd
+++ b/Modality/MKtlDescriptions/faderfox_uc4/faderfox-uc4_pg.desc.scd
@@ -24,7 +24,7 @@ knpg8 [\kn, \pbt][index]
 "Tutorials/Hardware_paging".openHelpFile;
 
 MKtlDesc.loadDescs("*uc4_pg");
-m.free; m = MKtl(\uc4, "*uc4_pg"); m.trace.gui;
+m.free; m = MKtl(\uc4_pg, "*uc4_pg"); m.trace.gui;
 
 ****/
 
@@ -33,8 +33,9 @@ parentDesc: "faderfox-uc4",
 
 status: (
 	linux: "unknown",
-	osx: "tested and working. 2016-04-10, adc",
-	win: "unknown"),
+	osx: "tested and working. 2019-12-29, adc",
+	win: "unknown"
+),
 
 elementsDesc: (
 	shared: ('midiChan': 0, ioType: \inout),
@@ -61,7 +62,7 @@ elementsDesc: (
 							midiNum: knum1 + i,
 							\style: ( \row: i div: 4 * 2,
 								\column: i % 4 * 2 + 0.5,
-								// showLabel: true
+								showLabel: true
 							),
 							\page: gr_i
 						)
@@ -82,8 +83,8 @@ elementsDesc: (
 							style: (\row: i div: 4 * 2 + 0.8,
 								\column: i % 4 * 2 + 0.5,
 								height: 0.8,
-								label: "pbt_" ++ (i + 1)
-								// showLabel: true
+								// label: "pbt_" ++ (i + 1),
+								showLabel: true
 							)
 						)
 					}
@@ -119,7 +120,7 @@ elementsDesc: (
 			elements: 8.collect { |i|
 				(
 					key: nil, midiNum: (btNum1[gr_i] + i),
-					label: ("bt_" ++ (i + 1)),
+					// label: ("bt_" ++ (i + 1)),
 					style: ( \row: 7, \column: i, height: 1)
 				)
 			};

--- a/Modality/MKtlDescriptions/icon-icontrols-pro.desc.scd
+++ b/Modality/MKtlDescriptions/icon-icontrols-pro.desc.scd
@@ -6,6 +6,7 @@ d = MKtlDesc.loadDescs("*icontrols-pro").first;
 d.elementsDict.size;
 // d.web;
 
+MKtlDesc.loadDescs("*icontrols-pro");
 m.free; m = MKtl(\ic, "*icontrols-pro");
 g = m.gui;
 g.views.size;
@@ -39,7 +40,7 @@ elementsDesc: (
 	elements: [
 		(
 			key: \bt,
-			shared: (elementType: \pad, ioType: \inout, groupType: \noteOnOffBut,
+			shared: (elementType: \pad, ioType: \inout,
 				midiMsgType: \noteOn, midiChan: 0, spec: \midiBut, mode: \push ),
 			elements: [
 				(
@@ -47,16 +48,19 @@ elementsDesc: (
 					elements: (0..7).collect { |num, i|
 						(
 							key: (i+1).asSymbol,
+							groupType: \noteOnOffBut,
 							midiNum: num,
-							shared: (style: (row: 0, column: i))
+							style: (row: 0, column: i)
 						)
 					}
 				),
 				(
 					key: \solo,
+
 					elements: (8..15).collect { |num, i|
 						(
 							key: (i+1).asSymbol,
+							groupType: \noteOnOffBut,
 							midiNum: num,
 							shared: (style: (row: 1, column: i))
 						)
@@ -67,6 +71,7 @@ elementsDesc: (
 					elements: (16..23).collect { |num, i|
 						(
 							key: (i+1).asSymbol,
+							groupType: \noteOnOffBut,
 							midiNum: num,
 							shared: (style: (row: 2, column: i))
 						)
@@ -74,10 +79,12 @@ elementsDesc: (
 				),
 				(
 					key: \select,
+					groupType: \noteOnOffBut,
 					// assuming this is 24-31? was 16-23, copy paste error?
 					elements: (24..31).collect { |num, i|
 						(
 							key: (i+1).asSymbol,
+							groupType: \noteOnOffBut,
 							midiNum: num,
 							shared: (style: (row: 3, column: i))
 						)
@@ -88,13 +95,13 @@ elementsDesc: (
 		(
 			key: \kn,
 			shared: (midiMsgType: \cc, elementType: \encoder,
-				ioType: \inout, midiChan: 0, spec: \midiCC, mode: \mackie ),
+			ioType: \inout, midiChan: 0, spec: \midiCC, mode: \mackie ),
 			elements: (16..23).collect { |num, i| (midiNum: num) }
 		),
 		(
 			key: \sl,
 			shared: (midiMsgType: \bend, elementType: \slider,
-				ioType: \inout, spec: \midiBend),
+			ioType: \inout, spec: \midiBend),
 			elements: 9.collect { |i| (midiChan: i) }
 		)
 	]

--- a/Modality/MKtlDescriptions/icon-icontrols-pro.desc.scd
+++ b/Modality/MKtlDescriptions/icon-icontrols-pro.desc.scd
@@ -79,7 +79,6 @@ elementsDesc: (
 				),
 				(
 					key: \select,
-					groupType: \noteOnOffBut,
 					// assuming this is 24-31? was 16-23, copy paste error?
 					elements: (24..31).collect { |num, i|
 						(

--- a/Modality/MKtlDescriptions/makenoise-0coast.desc.scd
+++ b/Modality/MKtlDescriptions/makenoise-0coast.desc.scd
@@ -44,13 +44,11 @@ elementsDesc: (
 		(
 			key: \key,
 			shared:  (\elementType: \pad,
-				\midiChan: 0, \spec: \midiVel, \ioType: \out),
+			\midiChan: 0, \spec: \midiVel, \ioType: \out),
 			elements: (0..124).collect { |num, i| (
-				shared: (midiNum: num),
-				elements: [
-					(key: \on,  midiMsgType: \noteOn ),
-					(key: \off, midiMsgType: \noteOff)
-				]
+				midiNum: num,
+				groupType: \noteOnOff,
+				style: (row: i div: 24, column: i % 24)
 			)}
 		),
 		(

--- a/Modality/MKtlDescriptions/novation-launchpad.desc.scd
+++ b/Modality/MKtlDescriptions/novation-launchpad.desc.scd
@@ -2,6 +2,12 @@
 // Mostly NoteOn / NoteOff, some cc messages,
 // no hardware scenes, flattened out with underscores
 
+/*
+MKtlDesc.loadDescs("*launchpad");
+m.free; m = MKtl(\lp, "*launchpad");  m.gui;
+*/
+
+
 (
 deviceName: "Launchpad",
 protocol: \midi,
@@ -9,7 +15,7 @@ deviceType: \launchpad,
 elementTypes: [\button],
 status: (
 	linux: "unknown",
-	osx: "tested desc, looks good. needs gui layout. 2016_03_23, adc",
+	osx: "now with gui layout. 2019_12_29, adc",
 	win: "unknown"),
 
 idInfo: "Launchpad",
@@ -49,19 +55,20 @@ elementsDesc: (
 		(
 			key: \pad,
 			shared: (\elementType: \pad, \spec: \midiVel),
-			elements: ((0, 16 .. 112) +.t (0..7)).flat.collect {|num, i|
+			elements: ((0, 16 .. 112) +.t (0..7)).flat.clump(8).collect {|nums, i|
 				(
-					elements: [
-						(key: \on, \midiMsgType: \noteOn, \midiNum: num),
-						(key: \off, \midiMsgType: \noteOff, \midiNum: num)
-					]
+					elements: nums.collect { |num, j|
+						( groupType: \noteOnOff,
+							style: (row: i + 1, column: j)
+						)
+					}
 				)
 			}
 		),
 		(
 			key: \arr,
 			shared: (\midiMsgType: \noteOn, \elementType: \pad, \spec: \midiVel),
-			elements: ((0, 16 .. 112) + 8).flat.collect {|num, i|
+			elements: ((0, 16 .. 112) + 8).flat.postln.collect {|num, i|
 				(\midiNum: num)
 			}
 		)

--- a/Modality/MKtlDescriptions/teenage-engineering-op-1.desc.scd
+++ b/Modality/MKtlDescriptions/teenage-engineering-op-1.desc.scd
@@ -4,10 +4,12 @@
 
 /* test that this works:
 
-MKtl.find;
-m = MKtl('op1', "teenage-engineering-op-1");
+d = MKtlDesc.loadDescs("*op-1").first;
+m.free; m = MKtl('op1', "*op-1");
 m.trace;
 m.gui;
+
+
 m.elAt(\bt, \4).addAction({ |el| "but 4: %\n".postf(el.value); });
 m.elAt(\btBubble).action_({ |el| "btBubble: %\n".postf(el.value); });
 m.elAt(\key, 0).action_({ |el| "keyOn: %\n".postf(el.value); });
@@ -48,14 +50,12 @@ elementsDesc: (
 
 			key: \key,
 			shared:  (\elementType: \pad,
-				\midiChan: 0, \spec: \midiVel, \ioType: \in),
-			elements: (0..124).collect { |num, i| (
-				shared: (midiNum: num),
-				elements: [
-						(key: \on,  midiMsgType: \noteOn ),
-						(key: \off, midiMsgType: \noteOff)
-				]
-			)}
+			\midiChan: 0, \spec: \midiVel, \ioType: \in),
+			elements: (0..124).collect { |num, i|
+				( midiNum: num, groupType: \noteOnOffBut,
+					style: (row: i div: 12, column: i % 12)
+				)
+			}
 		),
 		(
 			key: \kn,
@@ -63,7 +63,7 @@ elementsDesc: (
 				(
 					key: \turn,
 					shared: (\midiMsgType: \cc, \elementType: \knob, \midiChan: 0,
-						\spec: \midiCC, \ioType: \in),
+					\spec: \midiCC, \ioType: \in),
 					elements: [(1..4), [\blue, \green, \white, \red]].flop
 					.collect { |desc, i|
 						var num, label;
@@ -74,7 +74,7 @@ elementsDesc: (
 				(
 					key: \hat,
 					shared: (midiMsgType: \cc, elementType: \button, \midiChan: 0,
-						\spec: \midiBut, \mode: \push, \ioType: \in),
+					\spec: \midiBut, \mode: \push, \ioType: \in),
 					elements: [(64..67), [\blue, \green, \white, \red]].flop
 					.collect { |desc, i|
 						var num, label;
@@ -87,13 +87,13 @@ elementsDesc: (
 		(
 			key: \bt,
 			shared: (\midiMsgType: \cc, \elementType: \button, \midiChan: 0,
-				\spec: \midiBut, \ioType: \in),
+			\spec: \midiBut, \ioType: \in),
 			elements: (11..14).collect { |num| (\midiNum: num) },
 		),
 		(
 			key: \btPreset,
 			shared: (\midiMsgType: \cc, \elementType: \button, \midiChan: 0,
-				\spec: \midiBut, \ioType: \in),
+			\spec: \midiBut, \ioType: \in),
 			elements: [50, 51, 52, 21, 22, 23, 24, 25].collect { |num|
 				(midiNum: num)
 			}


### PR DESCRIPTION
This PR will fix a number of issues when finished:
- for MIDI devices, expansion by groupType not working properly 
- midi responders for groupTypes not being built properly - #332, #331, #329, #326
- and GUIs were not showing some elements (they had size 0@0)

The changes are:
- added UnitTests for MKtlDesc
- in MKtlDesc, simplify parent / shared dict structures and test them
- in MKtlElementGroup, use the new scheme properly 
- in MKtlGUI, fix broken style lookup 

- improvement to individual descs that shows problems

Tested with many of my midi devices, and they all seem fully usable now!

-> So, Please test with yours, and let me know if you find any problems !
