### PR TITLE
Actually consider srcPortIndex when opening a MIDI device

### DIFF
--- a/Modality/Classes/MIDI/MIDIMKtlDevice.sc
+++ b/Modality/Classes/MIDI/MIDIMKtlDevice.sc
@@ -144,7 +144,7 @@ MIDIMKtlDevice : MKtlDevice {
 		// logic is still too loopy, but no time to simplify now.
 
 	//	"%: %: %\n".postf(thisMethod, \multiIndex, multiIndex);
-		foundInfo = MKtlLookup.findByIDInfo(lookupInfo.deviceName)
+		foundInfo = MKtlLookup.findByIDInfo(idInfo)
 		.at(multiIndex ? 0);
 
 		foundSources = foundInfo[\srcDevice];


### PR DESCRIPTION
I believe this should fix it for good.
I have no idea why this slipped through, but with this change,
the correct port is finally used.