### PR TITLE
MIDI: search with indexOfEqual instead of indexOf

### DIFF
--- a/Modality/Classes/MIDI/MIDIMKtlDevice.sc
+++ b/Modality/Classes/MIDI/MIDIMKtlDevice.sc
@@ -55,7 +55,7 @@ MIDIMKtlDevice : MKtlDevice {
 		this.cleanupElementsAndCollectives;
 		destination.notNil.if {
 			if ( thisProcess.platform.name == \linux ) {
-				midiOut.disconnect( MIDIClient.destinations.indexOf(destination) )
+				midiOut.disconnect( MIDIClient.destinations.indexOfEqual(destination) )
 			};
 			midiOut = nil;
 		};
@@ -254,7 +254,7 @@ MIDIMKtlDevice : MKtlDevice {
 		destination.notNil.if {
  			if ( thisProcess.platform.name == \linux ) {
 				midiOut = MIDIOut( 0 );
-				midiOut.connect( MIDIClient.destinations.indexOf(destination) )
+				midiOut.connect( MIDIClient.destinations.indexOfEqual(destination) )
 			} {
 				midiOut = MIDIOut( MIDIClient.destinations.indexOfEqual(destination), dstID );
 			};


### PR DESCRIPTION
Fixes #372 

When looking for midi sources or destinations, indexOfEqual should be used: two MIDIEndPoint instances that represent the same endpoint are equal but not identical.

```supercollider
MIDIEndPoint("dev","name",123) == MIDIEndPoint("dev","name",123) // true
MIDIEndPoint("dev","name",123) === MIDIEndPoint("dev","name",123) // false
```

The proposed change affects only Linux platforms. 

Example use case: reconnect to a device after it was unplugged and re-plugged.
`MIDIClient.destinations.indexOf(destination)` fails because `destination` is a cached object, equal but not identical to the new MIDIEndPoint created by the system after re-connection (which is the one stored in MIDIClient.destinations).

