### PR TITLE
minor desc updates (manta, launchpad)

### DIFF
--- a/Modality/MKtlDescriptions/novation-launchpad.desc.scd
+++ b/Modality/MKtlDescriptions/novation-launchpad.desc.scd
@@ -54,7 +54,7 @@ elementsDesc: (
 		),
 		(
 			key: \pad,
-			shared: (\elementType: \pad, \spec: \midiVel),
+			shared: (\elementType: \pad, \spec: \midiVel, \ioType: \inout),
 			elements: ((0, 16 .. 112) +.t (0..7)).flat.clump(8).collect {|nums, i|
 				(
 					elements: nums.collect { |num, j|
@@ -67,9 +67,15 @@ elementsDesc: (
 		),
 		(
 			key: \arr,
-			shared: (\midiMsgType: \noteOn, \elementType: \pad, \spec: \midiVel),
+			shared: (\elementType: \pad, \spec: \midiVel),
 			elements: ((0, 16 .. 112) + 8).flat.postln.collect {|num, i|
-				(\midiNum: num)
+				(
+					groupType: \noteOnOff,
+					\midiNum: num,
+					style: (row: 10, column: i)
+
+
+				)
 			}
 		)
 	]

--- a/Modality/MKtlDescriptions/snyderphonics-manta.desc.scd
+++ b/Modality/MKtlDescriptions/snyderphonics-manta.desc.scd
@@ -91,7 +91,7 @@ testCode: {
 specs: (
 	mantaTouch: [ 0, 227 ].asSpec, // this seems to be the spec, looking at the github source code
 	mantaSlider: [ 0, 4095 ].asSpec, // slider sends values between 0 and 4095, releasing the slider sends 65536
-	mantaLed: ItemsSpec.new( ["off","amber","red"] ), // led can be off, amber or red
+	mantaLed: ItemsSpec.new( ["off","red", "amber"] ), // led can be off, red, or amber
 ),
 
 deviceInfo: (

--- a/Modality/MKtlDescriptions/snyderphonics-manta.desc.scd
+++ b/Modality/MKtlDescriptions/snyderphonics-manta.desc.scd
@@ -52,6 +52,9 @@ testCode: {
 
 	// enable LED control and set one light
 	m.sendSpecialMessage(\enableLEDControl);
+
+	// Manta v.2 has two different LED colors; amber and red
+	// Manta v.1 has only amber.
 	m.elAt(\pad, 0, \led).deviceValue = "amber";
 
 	// some light patterns
@@ -79,7 +82,8 @@ testCode: {
 	];
 
 	q.ledPatterns.choose.do{|val, i|
-		m.elAt(\pad, 0, \led).value = 0.5 * val;
+		// amber is 0.5, red is 1
+		m.elAt(\pad, i, \led).value = 0.5 * val;
 	};
 
 },

--- a/Modality/MKtlDescriptions/snyderphonics-manta.desc.scd
+++ b/Modality/MKtlDescriptions/snyderphonics-manta.desc.scd
@@ -82,8 +82,8 @@ testCode: {
 	];
 
 	q.ledPatterns.choose.do{|val, i|
-		// amber is 0.5, red is 1
-		m.elAt(\pad, i, \led).value = 0.5 * val;
+		// amber is 1, red is 0.5
+		m.elAt(\pad, i, \led).value = val;
 	};
 
 },


### PR DESCRIPTION
minor fixes to 

+ Manta desc
  + changed order of amber and red lights such that amber is equal to `1`, resolving a potential use error with Manta v.1 (no red leds)
    ```
    m.elAt(\pad, 0, \led).value = 1; // light up amber, no matter what manta version
    m.elAt(\pad, 0, \led).value = 0; // no light, no matter what manta version
    m.elAt(\pad, 0, \led).value = 0.5; // version 1: no light, v2: red
    ``` 
  + example code typo
+ launchpad
  + added possibility to light pads
  + added release event (noteOff) for arrow keys