### PR TITLE
feat: add \hide to styling dict to allow hiding elements from gui

### DIFF
--- a/Modality/Classes/GUI/MKtlGUI.sc
+++ b/Modality/Classes/GUI/MKtlGUI.sc
@@ -276,6 +276,15 @@ MKtlGUI {
 		"%: will show %'s % elements in % views.\n".postf(thisMethod, mktl,
 			mktl.elementsDict.size, elemsToShow.size);
 
+        // Remove elements that have the hide flag set in the style dict
+        elemsToShow = elemsToShow.reject({ |el|
+            var result = try {el.elemDesc[ \style ].notNil && el.elemDesc[ \style ][ \hide ] == true} ? false;
+            // var result = try{el.elemDesc[\style][\hide]} ? false;
+
+            result.if("Removing element % because it has the hide flag set in the style dict.\n".postf(el.name));
+            result
+        });
+
 		views = elemsToShow.collect({ |item|
 			var style, bounds, parView = parent, redirView, newViews;
 			var itemIsGroup = item.isKindOf(MKtlElementGroup);
@@ -394,7 +403,22 @@ MKtlGUI {
 		if (mktl.elementGroup.elements.isEmpty) {
 			^[1, 2]
 		};
-		^mktl.elementGroup.flat.collect({ |item|
+		^mktl.elementGroup.flat
+        // Remove element from count if it is hidden
+        .reject({|item|
+			var desc = item.elemDesc;
+
+            if(desc.isNil, {
+                false
+            }, {
+                if(desc[ \style ].isNil, {
+                    false
+                }, {
+                    desc[ \style ][ \hide ] == true
+                })
+            })
+
+        }).collect({ |item|
 			var desc = item.elemDesc;
 			desc !? {
 				((desc[ \style ] ?? { ( row: 0, column: 0, width: 0, height: 0 ) })


### PR DESCRIPTION
Hi! 
This is something I found useful for myself – the ability to hide an element from a gui. This is for example useful for devices like sequencers where it is hard to create a 1:1 representation of the midi notes received by SuperCollider in a GUI and it's just easier to hide it from the GUI and only interface with it in code. Example:

```supercollider

(
                        key: midiNoteNum.asSymbol,
                        midiNum: midiNoteNum,
                        elementType: \pad,
                        ioType: \in,
                        midiMsgType: \noteOnOff,
                        groupType: \noteOnOff,
                        midiChan: midiChan,
                        page: midiChan,
                        style: (
                            hide: true,
                            showLabel: false
                        ),
                    )
```