### PR TITLE
Fix faderfox ec4

### DIFF
--- a/Modality/MKtlDescriptions/faderfox_ec4/faderfox_ec4.desc.scd
+++ b/Modality/MKtlDescriptions/faderfox_ec4/faderfox_ec4.desc.scd
@@ -44,7 +44,7 @@ elementsDesc:
 					shared: (elementType: \knob, midiMsgType: \cc14, spec: \midiCC14),
 					elements: (0..15).collect {|midiNum, i|
 						( midiNum: midiNum,
-							style: (row: i div: 4 , column: (i % 4) * 2, width: 0.5, height: 1)
+							style: (row: i div: 4 , column: (i % 4) * 2, width: 1, height: 1)
 						)
 					}
 				),
@@ -53,7 +53,7 @@ elementsDesc:
 					shared: (elementType: \button, groupType: \noteOnOffBut),
 					elements: (0..15).collect {|midiNum, i|
 						( midiNum: midiNum,
-							style: (row: i div: 4 , column: (i % 4) * 2 + 1, width: 0.5, height: 1)
+							style: (row: i div: 4 , column: (i % 4) * 2 + 1, width: 1, height: 1)
 						)
 
 					}

--- a/Modality/MKtlDescriptions/faderfox_ec4/faderfox_ec4.desc.scd
+++ b/Modality/MKtlDescriptions/faderfox_ec4/faderfox_ec4.desc.scd
@@ -35,7 +35,7 @@ elementsDesc:
 	elements: (0..15).collect{|midiChan|
 		(
 			key: "GR%".format((100 + midiChan+1).asString[1..]).asSymbol,
-			shared: (midiChan: midiChan),
+			shared: (midiChan: midiChan, page: midiChan),
 
 
 			elements: [


### PR DESCRIPTION
Here are a couple of small fixes for the gui of the faderfox ec4. The knobs were tiny and the hardware paging wasn't used. This fixes both those problems. 

@LFSaw Does this look alright to you?