### PR TITLE
Multiple devices interfere with each other if no dest id provided

### DIFF
--- a/Modality/Classes/MIDI/MIDIMKtlDevice.sc
+++ b/Modality/Classes/MIDI/MIDIMKtlDevice.sc
@@ -262,7 +262,7 @@ MIDIMKtlDevice : MKtlDevice {
 
 		destination.notNil.if {
  			if ( thisProcess.platform.name == \linux ) {
-				midiOut = MIDIOut( 0 );
+				midiOut = MIDIOut( 0, dstID );
 				midiOut.connect( MIDIClient.destinations.indexOfEqual(destination) )
 			} {
 				midiOut = MIDIOut( MIDIClient.destinations.indexOfEqual(destination), dstID );


### PR DESCRIPTION
On linux, if you have several devices that accept same MIDI messages, you need to connect them to different output/input in jackd, else a midi message will affect both devices. With Modality, connections are made for you all on the first output port of supercollider. It seems not trivial to change Modality to start bookkeeping which device use which port, but adding the device id to MIDIOut solve the problem neatly